### PR TITLE
Added new ansible role for galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Datadog
 
-Master: [![Build Status](https://travis-ci.org/sansible/datadog.svg?branch=master)](https://travis-ci.org/sansible/datadog)
-Develop: [![Build Status](https://travis-ci.org/sansible/datadog.svg?branch=develop)](https://travis-ci.org/sansible/datadog)
-
 * [ansible.cfg](#ansible-cfg)
 * [Installation and Dependencies](#installation-and-dependencies)
 * [Tags](#tags)
@@ -32,12 +29,12 @@ hash_behaviour = merge
 
 ## Installation and Dependencies
 
-To install run `ansible-galaxy install sansible.datadog` or add this to your
+To install run `ansible-galaxy install cloudposse.ansible-datadog` or add this to your
 `roles.yml`.
 
 ```YAML
-- name: sansible.datadog
-  version: v1.1
+- name: cloudposse.ansible-datadog
+  version: origin/master
 ```
 
 and run `ansible-galaxy install -p ./roles -r roles.yml`
@@ -47,8 +44,6 @@ and run `ansible-galaxy install -p ./roles -r roles.yml`
 
 ## Tags
 
-This role uses one tag: **build**
-
 * `build` - Installs Datadog and all it's dependencies.
 * `configure` - Configures datadog and install integrations
 
@@ -57,7 +52,7 @@ This role uses one tag: **build**
 
 ## Integrations
 
-The `datadog/templates/conf.d` directory contains the implemented integrations. The majority of them are self explanatory.
+The `ansible-datadog/templates/conf.d` directory contains the implemented integrations. The majority of them are self explanatory.
 
 #### TCP Check
 
@@ -65,7 +60,7 @@ Sample data structure for TCP Check integration.
 
 ```
 roles:
-  - role: sansible.datadog
+  - role: ansible-datadog
     datadog:
       integrations:
         tcp_check:
@@ -95,7 +90,7 @@ To install:
   hosts: "somehost"
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
 ```
 
 Setup Datadog with some integrations and tags:
@@ -105,7 +100,7 @@ Setup Datadog with some integrations and tags:
   hosts: "somehost"
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
       datadog:
         integrations:
           php_fpm: { }
@@ -134,7 +129,7 @@ datadog:
     - vars/dev/vars.yml
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
 ```
 
 **Note** This behaviour requires hash_behaviour to be set to merge.
@@ -151,7 +146,7 @@ another role:
     - vars/dev/vars.yml
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
       datadog:
         autostart_agent: no
 
@@ -177,7 +172,7 @@ datadog:
     - vars/dev/vars.yml
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
       datadog:
         tags:
           - some_app
@@ -201,7 +196,8 @@ Disable Datadog service (useful for disabling in some environments):
   hosts: "somehost"
 
   roles:
-    - role: sansible.datadog
+    - role: ansible-datadog
       datadog:
         enabled: false
 ```
+# datadog

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,2 @@
 ---
 
-datadog:
-  api_key: changeme
-  autostart_agent: yes
-  dd_url: https://app.datadoghq.com
-  default_tags: [ ]
-  enabled: yes
-  integrations: { }
-  socket: "/opt/datadog-agent/run/datadog-supervisor.sock"
-  tags: [ ]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,34 +1,16 @@
 ---
+
+dependencies: [ ]
+
 galaxy_info:
-  author: 'Cloudposse'
-  description: Datadog agent and modules installation
+  author: David Reed
+  description: Datadog agent installation
   license: MIT
-  min_ansible_version: 1.6
+  min_ansible_version: 2.0
   platforms:
     - name: Ubuntu
       versions:
-        - lucid
-        - maverick
-        - natty
-        - oneiric
         - precise
-        - quantal
-        - raring
-        - saucy
         - trusty
-        - utopic
-        - vivid
-        - xenial
-    - name: Debian
-      versions:
-        - squeeze
-        - wheezy
-        - jessie
-    - name: EL
-      versions:
-        - 7
-        - 6
-        - 5
   categories:
-    - monitoring
-dependencies: []
+    - development

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,34 @@
 ---
-
-dependencies: [ ]
-
 galaxy_info:
-  author: David Reed
-  description: Datadog agent installation
-  license: MIT
-  min_ansible_version: 2.0
+  author: 'Cloudposse'
+  description: Install Datadog agent and configure checks
+  license: Apache 2
+  min_ansible_version: 1.6
   platforms:
     - name: Ubuntu
       versions:
+        - lucid
+        - maverick
+        - natty
+        - oneiric
         - precise
+        - quantal
+        - raring
+        - saucy
         - trusty
+        - utopic
+        - vivid
+        - xenial
+    - name: Debian
+      versions:
+        - squeeze
+        - wheezy
+        - jessie
+    - name: EL
+      versions:
+        - 7
+        - 6
+        - 5
   categories:
-    - development
+    - monitoring
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
   author: 'Cloudposse'
-  description: Install Datadog agent and configure checks
-  license: Apache 2
+  description: Datadog agent and modules installation
+  license: MIT
   min_ansible_version: 1.6
   platforms:
     - name: Ubuntu

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,28 +1,6 @@
 ---
+- include: pkg-debian.yml
+  when: ansible_os_family == "Debian"
 
-- name: Ensures Datadog PGP key is known to the server
-  become: yes
-  apt_key:
-    id: C7A7DA52
-    keyserver: keyserver.ubuntu.com
-    state: present
-
-- name: Add Datadog repo
-  become: yes
-  apt_repository:
-    repo: deb http://apt.datadoghq.com/ stable main
-    state: present
-    update_cache: yes
-
-- name: Install Agent
-  become: yes
-  apt:
-    name: datadog-agent
-    state: latest
-
-- name: Stop and disable datadog
-  become: yes
-  service:
-    name: datadog-agent
-    enabled: no
-    state: stopped
+- include: pkg-redhat.yml
+  when: ansible_os_family == "RedHat"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,0 +1,35 @@
+---
+- name: Install apt-transport-https
+  apt: name=apt-transport-https state=present
+
+- name: Install ubuntu apt-key server
+  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE keyserver=hkp://keyserver.ubuntu.com:80 state=present
+  when: datadog_apt_key_url_new is not defined
+
+- name: Install Datadog apt-key
+  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
+  when: datadog_apt_key_url_new is defined
+
+- name: Ensure ubuntu apt-key server is present
+  apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
+  when: datadog_apt_key_url is not defined
+
+- name: Ensure Datadog apt-key is present
+  apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
+  when: datadog_apt_key_url is defined
+
+- name: Ensure Datadog repository is up-to-date
+  apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
+
+- name: Ensure pinned version of Datadog agent is installed
+  apt:
+    name: datadog-agent={{ datadog_agent_version }}
+    state: present
+    force: "{{ datadog_agent_allow_downgrade }}"
+  when: datadog_agent_version != ""
+
+- name: Ensure Datadog agent is installed
+  apt:
+    name: datadog-agent
+    state: latest
+  when: datadog_agent_version == ""

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,0 +1,24 @@
+---
+- name: Download new RPM key
+  get_url:
+    url: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
+
+- name: Import new RPM key
+  rpm_key: key=/tmp/DATADOG_RPM_KEY_E09422B3.public state=present
+
+- name: Copy repo file into place
+  template: src=datadog.repo.j2 dest=/etc/yum.repos.d/datadog.repo owner=root group=root mode=0644
+
+- name: Install pinned datadog-agent package
+  yum:
+    name: datadog-agent-{{ datadog_agent_version }}
+    state: present
+  when: datadog_agent_version != ""
+
+- name: Install latest datadog-agent package
+  yum:
+    name: datadog-agent
+    state: latest
+  when: datadog_agent_version == ""


### PR DESCRIPTION
## What
* Added ansible role for deploy datadog's agent on servers with support for CentOS, Debian, and Ubuntu 

## Why
* Needs to be public this role on Ansible Galaxy (galaxy.ansible.com)