### PR TITLE
Added template file for datadog RPM repository

### DIFF
--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -1,0 +1,6 @@
+[datadog]
+name = Datadog, Inc.
+baseurl = https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public


### PR DESCRIPTION
## What
* Added template file for a datadog RPM repository

## Why
*  We need this in order to add RPM datadog repository on a new host.