### PR TITLE
Add option to pin `datadog_agent_version` variable

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -23,13 +23,13 @@
 
 - name: Ensure pinned version of Datadog agent is installed
   apt:
-    name: datadog-agent={{ datadog_agent_version }}
+    name: datadog-agent={{ deb_agent_version }}
     state: present
     force: "{{ datadog_agent_allow_downgrade }}"
-  when: datadog_agent_version != ""
+  when: deb_agent_version != ""
 
 - name: Ensure Datadog agent is installed
   apt:
     name: datadog-agent
     state: latest
-  when: datadog_agent_version == ""
+  when: deb_agent_version == ""

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -13,12 +13,12 @@
 
 - name: Install pinned datadog-agent package
   yum:
-    name: datadog-agent-{{ datadog_agent_version }}
+    name: datadog-agent-{{ rpm_agent_version }}
     state: present
-  when: datadog_agent_version != ""
+  when: rpm_agent_version != ""
 
 - name: Install latest datadog-agent package
   yum:
     name: datadog-agent
     state: latest
-  when: datadog_agent_version == ""
+  when: rpm_agent_version == ""


### PR DESCRIPTION
## What
* Add option to pin `datadog_agent_version` variable

## Why
* RedHat and Debian have different names of agent version